### PR TITLE
feat: save map colour

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_service_files(
   LoadEnvironments.srv
   LoadMap.srv
   SaveMap.srv
+  SaveMapColour.srv
   DumpMap.srv
 )
 

--- a/package.xml
+++ b/package.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>multimap_server_msgs</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>The multimap_server_msgs package</description>
 
-  <maintainer email="avillena@robotnik.es">Álvaro Villena</maintainer>
+  <maintainer email="rnavarro@robotnik.es">Román Navarro</maintainer>
 
   <license>BSD</license>
 

--- a/srv/SaveMapColour.srv
+++ b/srv/SaveMapColour.srv
@@ -1,0 +1,11 @@
+string map_service
+string map_filename
+bool use_default_thresholds
+float32 threshold_occupied
+float32 threshold_free
+int16 colour_occupied
+int16 colour_free
+int16 colour_unknown
+---
+bool success
+string msg


### PR DESCRIPTION
This pull request includes several changes to the `multimap_server_msgs` package, primarily focusing on adding a new service file, updating the package version, and changing the maintainer information.

### New Features:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR19): Added a new service file `SaveMapColour.srv` to the list of service files.
* [`srv/SaveMapColour.srv`](diffhunk://#diff-445e36fa2eb803c536498824304d89ed4f29c65e7c6c20b4748717b3b5515316R1-R11): Created a new service definition file `SaveMapColour.srv` with fields for map service, filename, thresholds, and colors.

### Maintenance Updates:
* [`package.xml`](diffhunk://#diff-37a67ff78eb7260214b323353263b9af40a2fa98719a1e81937fae0159df87a3L4-R7): Updated the package version from `1.0.0` to `1.1.0` and changed the maintainer from Álvaro Villena to Román Navarro.